### PR TITLE
serializers: override schemas for better facets

### DIFF
--- a/invenio_global_search/serializers.py
+++ b/invenio_global_search/serializers.py
@@ -34,6 +34,19 @@ try:
     from invenio_records_lom.resources.serializers.dublincore.schema import (
         LOMToDublinCoreRecordSchema,
     )
+    from invenio_records_lom.utils import LOMMetadata
+
+    class GlobalSearchLOMToDublinCoreRecordSchema(LOMToDublinCoreRecordSchema):
+        """Override methods from invenio_records_lom LOMToDublinCoreRecordSchema."""
+
+        def get_rights(self, lom: LOMMetadata) -> list:
+            """Get rights.
+
+            Method was overriden to take just the name of the right, no need for
+            link in global-search context.
+            """
+            params = ["name"]
+            return lom.get_rights(params=params)
 
     class LOMRecordJSONSerializer(MarshmallowSerializer):
         """Marshmallow based DataCite serializer for records."""
@@ -42,7 +55,7 @@ try:
             """Construct."""
             super().__init__(
                 format_serializer_cls=JSONSerializer,
-                object_schema_cls=LOMToDublinCoreRecordSchema,
+                object_schema_cls=GlobalSearchLOMToDublinCoreRecordSchema,
                 list_schema_cls=BaseListSchema,
             )
 


### PR DESCRIPTION
- override `get_rights()` and `get_types()` for better visual display in global-search context (only applicable for Research Results)
- until now there was used `RDMDublinCoreSchema` which:
 
    - populated the _rights_ list with both license titles (which we would still want) and also license URLs. The facets in global-search then showed also links to the already existing titles (double info and also ugly with links).
    - populated the _types_ list with pseudo-links which looked ugly. Added some string processing to extract the relevant resource type.

Research Results:
before:
![image](https://github.com/user-attachments/assets/3d051936-7d2d-4f05-be22-ddbd2cfd584e)

after:
![image](https://github.com/user-attachments/assets/af4051f3-d177-42da-9df1-74b2722473d7)

- override `get_rights()` for lom package to get only the license name

OER:
before:
![image](https://github.com/user-attachments/assets/7038f6c9-34e8-4e02-a6d9-dad92bc1c428)

after: 
![image](https://github.com/user-attachments/assets/aa8eeaa1-9b5a-4834-bd84-207d7cfcf0d3)
