### PR TITLE
fix(oai): lom allows per defintion only lom

### DIFF
--- a/invenio_global_search/oai.py
+++ b/invenio_global_search/oai.py
@@ -52,6 +52,7 @@ from invenio_pidstore.errors import PersistentIdentifierError, PIDDoesNotExistEr
 from invenio_pidstore.fetchers import FetchedPID
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records_resources.services.records.results import RecordItem
+from lxml.etree import Element
 
 try:
     from invenio_rdm_records.oai import dublincore_etree
@@ -125,18 +126,22 @@ def gs_lom_etree(
     """GS-to-LOM adapter for lom metadata format."""
     try:
         if "original" not in record["_source"]:
-            return lom_etree(pid, record)
+            return Element("not-lom")
 
         original = record["_source"]["original"]
-        pid_value = original["pid"]
+
+        if original["schema"] != "lom":
+            return Element("not-lom")
+
         lom_record_idx_view = current_search_client.search(
             index=f"{LOMRecord.index._name}",  # noqa: SLF001
-            body={"query": {"term": {"id": pid_value}}},
+            body={"query": {"term": {"id": original["pid"]}}},
         )
         hits = lom_record_idx_view["hits"]["hits"]
         if len(hits) > 0:
             return lom_etree(pid, hits[0])
-        return lom_etree(pid, record)
+
+        return Element("not-lom")
     except NameError:
         raise RuntimeError(_generic_name_err_msg.format(_lom_str)) from None
 


### PR DESCRIPTION
* the problem is, per definition at the moment the metadata prefix can
  only provide real lom records. it is not allowed to provide other
  records converted to lom. yes the standard would allow or better
  encourage that, but what is defined at the moment over the OEAA
  project prohibits that. only records from datamodel lom are allowed to
  be imported in the OERhub because only they are created by people with
  the training and the certificate
